### PR TITLE
Update uhd.lwr to reference the LTS branch

### DIFF
--- a/uhd.lwr
+++ b/uhd.lwr
@@ -32,7 +32,7 @@ satisfy:
   port: uhd
   portage: net-wireless/uhd
 source: git+https://github.com/EttusResearch/uhd.git
-gitbranch: master
+gitbranch: UHD-3.9.LTS
 #gitbranch: rfnoc-devel
 inherit: cmake
 configuredir: host/build


### PR DESCRIPTION
UHD development occurs on master and this causes the current recipe to sometimes pull a non-functioning commit. Tied to current LTS branch for best compatibility. 
Solves: #157